### PR TITLE
Add `AUTHORS`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,1 @@
+Marko Ristin (marko@ristin.ch, marko.ristin@gmail.com, rist@zhaw.ch) for Zurich University of Applied Sciences (ZHAW)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 aas-core-works
+Copyright (c) 2023 aas-core3.0-micropython AUTHORS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,3 +19,5 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+Please see the file AUTHORS for the full list of the authors of aas-core3.0-micropython.


### PR DESCRIPTION
We add the file `AUTHORS` to clearly list the authors bearing the copyright.

We follow the structure of the Chromium project, see [this StackExchange question].

[this StackExchange question]: https://opensource.stackexchange.com/questions/4960/can-a-team-be-the-copyright-holder-mit