### PR TITLE
Update to aas-core3.0-python 1.0.4

### DIFF
--- a/aas_core3/__init__.py
+++ b/aas_core3/__init__.py
@@ -1,7 +1,7 @@
 """Manipulate and de/serialize Asset Administration Shells in Micropython."""
 
 # Synchronize with __init__.py and changelog.rst!
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 __author__ = "Marko Ristin"
 __copyright__ = "2024 Contributors to aas-core3.0-python"
 __license__ = "License :: OSI Approved :: MIT License"

--- a/aas_core3/jsonization.py
+++ b/aas_core3/jsonization.py
@@ -4960,22 +4960,22 @@ class _SetterForEmbeddedDataSpecification:
 
     def __init__(self):
 
-        self.data_specification = None
         self.data_specification_content = None
+        self.data_specification = None
 
     def ignore(self, jsonable):
 
         pass
-
-    def set_data_specification_from_jsonable(self, jsonable):
-
-        self.data_specification = reference_from_jsonable(jsonable)
 
     def set_data_specification_content_from_jsonable(self, jsonable):
 
         self.data_specification_content = data_specification_content_from_jsonable(
             jsonable
         )
+
+    def set_data_specification_from_jsonable(self, jsonable):
+
+        self.data_specification = reference_from_jsonable(jsonable)
 
 
 def embedded_data_specification_from_jsonable(
@@ -4998,18 +4998,13 @@ def embedded_data_specification_from_jsonable(
             exception.path._prepend(PropertySegment(jsonable_value, key))
             raise exception
 
-    if setter.data_specification is None:
-        raise DeserializationException(
-            "The required property 'dataSpecification' is missing"
-        )
-
     if setter.data_specification_content is None:
         raise DeserializationException(
             "The required property 'dataSpecificationContent' is missing"
         )
 
     return aas_types.EmbeddedDataSpecification(
-        setter.data_specification, setter.data_specification_content
+        setter.data_specification_content, setter.data_specification
     )
 
 
@@ -6076,8 +6071,8 @@ _DATA_SPECIFICATION_CONTENT_FROM_JSONABLE_DISPATCH = {
 
 
 _SETTER_MAP_FOR_EMBEDDED_DATA_SPECIFICATION = {
-    "dataSpecification": _SetterForEmbeddedDataSpecification.set_data_specification_from_jsonable,
     "dataSpecificationContent": _SetterForEmbeddedDataSpecification.set_data_specification_content_from_jsonable,
+    "dataSpecification": _SetterForEmbeddedDataSpecification.set_data_specification_from_jsonable,
     "modelType": _SetterForEmbeddedDataSpecification.ignore,
 }
 
@@ -7240,11 +7235,12 @@ class _Serializer(aas_types.AbstractTransformer):
 
         jsonable = dict()
 
-        jsonable["dataSpecification"] = self.transform(that.data_specification)
-
         jsonable["dataSpecificationContent"] = self.transform(
             that.data_specification_content
         )
+
+        if that.data_specification is not None:
+            jsonable["dataSpecification"] = self.transform(that.data_specification)
 
         return jsonable
 

--- a/aas_core3/jsonization.pyi
+++ b/aas_core3/jsonization.pyi
@@ -3143,17 +3143,17 @@ class _SetterForEmbeddedDataSpecification:
         """Ignore :paramref:`jsonable` and do not set anything."""
         ...
 
-    def set_data_specification_from_jsonable(self, jsonable: Jsonable) -> None:
+    def set_data_specification_content_from_jsonable(self, jsonable: Jsonable) -> None:
         """
-        Parse :paramref:`jsonable` as the value of :py:attr:`~data_specification`.
+        Parse :paramref:`jsonable` as the value of :py:attr:`~data_specification_content`.
 
         :param jsonable: input to be parsed
         """
         ...
 
-    def set_data_specification_content_from_jsonable(self, jsonable: Jsonable) -> None:
+    def set_data_specification_from_jsonable(self, jsonable: Jsonable) -> None:
         """
-        Parse :paramref:`jsonable` as the value of :py:attr:`~data_specification_content`.
+        Parse :paramref:`jsonable` as the value of :py:attr:`~data_specification`.
 
         :param jsonable: input to be parsed
         """

--- a/aas_core3/types.py
+++ b/aas_core3/types.py
@@ -3499,19 +3499,21 @@ class EmbeddedDataSpecification(Class):
 
     def descend_once(self):
 
-        yield self.data_specification
-
         yield self.data_specification_content
 
+        if self.data_specification is not None:
+            yield self.data_specification
+
     def descend(self):
-
-        yield self.data_specification
-
-        yield from self.data_specification.descend()
 
         yield self.data_specification_content
 
         yield from self.data_specification_content.descend()
+
+        if self.data_specification is not None:
+            yield self.data_specification
+
+            yield from self.data_specification.descend()
 
     def accept(self, visitor):
 
@@ -3537,12 +3539,12 @@ class EmbeddedDataSpecification(Class):
 
     def __init__(
         self,
-        data_specification,
         data_specification_content,
+        data_specification=None,
     ):
 
-        self.data_specification = data_specification
         self.data_specification_content = data_specification_content
+        self.data_specification = data_specification
 
 
 @aas_enum.decorator

--- a/aas_core3/types.pyi
+++ b/aas_core3/types.pyi
@@ -3550,11 +3550,11 @@ class DataSpecificationContent(Class):
 class EmbeddedDataSpecification(Class):
     """Embed the content of a data specification."""
 
-    #: Reference to the data specification
-    data_specification: "Reference"
-
     #: Actual content of the data specification
     data_specification_content: "DataSpecificationContent"
+
+    #: Reference to the data specification
+    data_specification: Optional["Reference"]
 
     def descend_once(self) -> Iterator[Class]:
         """
@@ -3600,8 +3600,8 @@ class EmbeddedDataSpecification(Class):
 
     def __init__(
         self,
-        data_specification: "Reference",
         data_specification_content: "DataSpecificationContent",
+        data_specification: Optional["Reference"] = None,
     ) -> None:
         """Initialize with the given values."""
         ...

--- a/aas_core3/xmlization.py
+++ b/aas_core3/xmlization.py
@@ -1987,13 +1987,14 @@ class _Serializer(aas_types.AbstractVisitor):
 
     def _write_embedded_data_specification_as_sequence(self, that):
 
-        self._write_start_element("dataSpecification")
-        self._write_reference_as_sequence(that.data_specification)
-        self._write_end_element("dataSpecification")
-
         self._write_start_element("dataSpecificationContent")
         self.visit(that.data_specification_content)
         self._write_end_element("dataSpecificationContent")
+
+        if that.data_specification is not None:
+            self._write_start_element("dataSpecification")
+            self._write_reference_as_sequence(that.data_specification)
+            self._write_end_element("dataSpecification")
 
     def visit_embedded_data_specification(self, that):
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as fid:
 setup(
     name='aas-core3.0-micropython',
     # Synchronize with __init__.py and changelog.rst!
-    version="1.0.3",
+    version="1.0.4",
     description="Manipulate and de/serialize Asset Administration Shells in Micropython.",
     long_description=long_description,
     url="https://github.com/aas-core-works/aas-core3.0-micropython",


### PR DESCRIPTION
Notably, we propagate [the fix #328 on aas-core-meta] related to `Embedded_data_specification` where `data_specification` is made optional.

[the fix #328 on aas-core-meta]: aas-core-works/aas-core-meta#328