### PR TITLE
Patch abstract `Set`'s with built-in `set`

### DIFF
--- a/dev_scripts/patch_aas_core_python.py
+++ b/dev_scripts/patch_aas_core_python.py
@@ -792,6 +792,12 @@ def _replace_collections_abc_with_native_types(text: str) -> str:
                     range=patching.cast_node_to_range(node), replacement="list"
                 )
             )
+        elif node.attr == "Set":
+            patches.append(
+                patching.Patch(
+                    range=patching.cast_node_to_range(node), replacement="set"
+                )
+            )
         else:
             raise NotImplementedError(f"Unhandled collections.abc: {ast.dump(node)}")
 


### PR DESCRIPTION
We replace `collections.abc.Set` with a built-in `set`. Micropython does not support `collections.abc`.