### PR TITLE
Add missing XML deserializers to filter list

### DIFF
--- a/dev_scripts/patch_aas_core_python.py
+++ b/dev_scripts/patch_aas_core_python.py
@@ -1212,6 +1212,11 @@ def _remove_xml_deserialization(
         "_read_float_from_element_text",
         "_read_str_from_element_text",
         "_read_bytes_from_element_text",
+        "from_iterparse",
+        "from_file",
+        "from_stream",
+        "from_str",
+        "_read_as_element",
     }
 
     variable_set_to_ignore = {
@@ -1219,6 +1224,7 @@ def _remove_xml_deserialization(
         "_NAMESPACE_IN_CURLY_BRACKETS",
         "Segment",
         "_TEXT_TO_XS_DOUBLE_LITERALS",
+        "_GENERAL_DISPATCH",
     }
 
     for stmt in atok.tree.body:


### PR DESCRIPTION
In MicroPython we have no support for XML deserialization. The patching script
therefore drops all deserialization functions when converting from python SDK.
In the current version the patching script misses some deserialization 
functions, resulting in MicroPython containing them. We add these missing 
function to the filter list.