### PR TITLE
Update to aas-core3.0-python 1.1.3

### DIFF
--- a/aas_core3/__init__.py
+++ b/aas_core3/__init__.py
@@ -1,7 +1,7 @@
 """Manipulate and de/serialize Asset Administration Shells in Micropython."""
 
 # Synchronize with __init__.py and changelog.rst!
-__version__ = "1.0.4"
+__version__ = "1.0.5"
 __author__ = "Marko Ristin"
 __copyright__ = "2024 Contributors to aas-core3.0-python"
 __license__ = "License :: OSI Approved :: MIT License"

--- a/aas_core3/jsonization.py
+++ b/aas_core3/jsonization.py
@@ -5269,22 +5269,22 @@ class _SetterForEmbeddedDataSpecification:
 
     def __init__(self):
 
-        self.data_specification_content = None
         self.data_specification = None
+        self.data_specification_content = None
 
     def ignore(self, jsonable):
 
         pass
+
+    def set_data_specification_from_jsonable(self, jsonable):
+
+        self.data_specification = reference_from_jsonable(jsonable)
 
     def set_data_specification_content_from_jsonable(self, jsonable):
 
         self.data_specification_content = data_specification_content_from_jsonable(
             jsonable
         )
-
-    def set_data_specification_from_jsonable(self, jsonable):
-
-        self.data_specification = reference_from_jsonable(jsonable)
 
 
 def embedded_data_specification_from_jsonable(
@@ -5307,18 +5307,18 @@ def embedded_data_specification_from_jsonable(
             exception.path._prepend(PropertySegment(jsonable_value, key))
             raise exception
 
-    if setter.data_specification_content is None:
-        raise DeserializationException(
-            "The required property 'dataSpecificationContent' is missing"
-        )
-
     if setter.data_specification is None:
         raise DeserializationException(
             "The required property 'dataSpecification' is missing"
         )
 
+    if setter.data_specification_content is None:
+        raise DeserializationException(
+            "The required property 'dataSpecificationContent' is missing"
+        )
+
     return aas_types.EmbeddedDataSpecification(
-        setter.data_specification_content, setter.data_specification
+        setter.data_specification, setter.data_specification_content
     )
 
 
@@ -6400,8 +6400,8 @@ _DATA_SPECIFICATION_CONTENT_FROM_JSONABLE_DISPATCH = {
 
 
 _SETTER_MAP_FOR_EMBEDDED_DATA_SPECIFICATION = {
-    "dataSpecificationContent": _SetterForEmbeddedDataSpecification.set_data_specification_content_from_jsonable,
     "dataSpecification": _SetterForEmbeddedDataSpecification.set_data_specification_from_jsonable,
+    "dataSpecificationContent": _SetterForEmbeddedDataSpecification.set_data_specification_content_from_jsonable,
     "modelType": _SetterForEmbeddedDataSpecification.ignore,
 }
 
@@ -7564,11 +7564,11 @@ class _Serializer(aas_types.AbstractTransformer):
 
         jsonable = dict()
 
+        jsonable["dataSpecification"] = self.transform(that.data_specification)
+
         jsonable["dataSpecificationContent"] = self.transform(
             that.data_specification_content
         )
-
-        jsonable["dataSpecification"] = self.transform(that.data_specification)
 
         return jsonable
 

--- a/aas_core3/jsonization.pyi
+++ b/aas_core3/jsonization.pyi
@@ -3178,17 +3178,17 @@ class _SetterForEmbeddedDataSpecification:
         """Ignore :paramref:`jsonable` and do not set anything."""
         ...
 
-    def set_data_specification_content_from_jsonable(self, jsonable: Jsonable) -> None:
+    def set_data_specification_from_jsonable(self, jsonable: Jsonable) -> None:
         """
-        Parse :paramref:`jsonable` as the value of :py:attr:`~data_specification_content`.
+        Parse :paramref:`jsonable` as the value of :py:attr:`~data_specification`.
 
         :param jsonable: input to be parsed
         """
         ...
 
-    def set_data_specification_from_jsonable(self, jsonable: Jsonable) -> None:
+    def set_data_specification_content_from_jsonable(self, jsonable: Jsonable) -> None:
         """
-        Parse :paramref:`jsonable` as the value of :py:attr:`~data_specification`.
+        Parse :paramref:`jsonable` as the value of :py:attr:`~data_specification_content`.
 
         :param jsonable: input to be parsed
         """

--- a/aas_core3/types.py
+++ b/aas_core3/types.py
@@ -3499,19 +3499,19 @@ class EmbeddedDataSpecification(Class):
 
     def descend_once(self):
 
-        yield self.data_specification_content
-
         yield self.data_specification
 
-    def descend(self):
-
         yield self.data_specification_content
 
-        yield from self.data_specification_content.descend()
+    def descend(self):
 
         yield self.data_specification
 
         yield from self.data_specification.descend()
+
+        yield self.data_specification_content
+
+        yield from self.data_specification_content.descend()
 
     def accept(self, visitor):
 
@@ -3537,12 +3537,12 @@ class EmbeddedDataSpecification(Class):
 
     def __init__(
         self,
-        data_specification_content,
         data_specification,
+        data_specification_content,
     ):
 
-        self.data_specification_content = data_specification_content
         self.data_specification = data_specification
+        self.data_specification_content = data_specification_content
 
 
 @aas_enum.decorator

--- a/aas_core3/types.pyi
+++ b/aas_core3/types.pyi
@@ -3550,11 +3550,11 @@ class DataSpecificationContent(Class):
 class EmbeddedDataSpecification(Class):
     """Embed the content of a data specification."""
 
-    #: Actual content of the data specification
-    data_specification_content: "DataSpecificationContent"
-
     #: Reference to the data specification
     data_specification: "Reference"
+
+    #: Actual content of the data specification
+    data_specification_content: "DataSpecificationContent"
 
     def descend_once(self) -> Iterator[Class]:
         """
@@ -3600,8 +3600,8 @@ class EmbeddedDataSpecification(Class):
 
     def __init__(
         self,
-        data_specification_content: "DataSpecificationContent",
         data_specification: "Reference",
+        data_specification_content: "DataSpecificationContent",
     ) -> None:
         """Initialize with the given values."""
         ...

--- a/aas_core3/xmlization.py
+++ b/aas_core3/xmlization.py
@@ -1987,13 +1987,13 @@ class _Serializer(aas_types.AbstractVisitor):
 
     def _write_embedded_data_specification_as_sequence(self, that):
 
-        self._write_start_element("dataSpecificationContent")
-        self.visit(that.data_specification_content)
-        self._write_end_element("dataSpecificationContent")
-
         self._write_start_element("dataSpecification")
         self._write_reference_as_sequence(that.data_specification)
         self._write_end_element("dataSpecification")
+
+        self._write_start_element("dataSpecificationContent")
+        self.visit(that.data_specification_content)
+        self._write_end_element("dataSpecificationContent")
 
     def visit_embedded_data_specification(self, that):
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     ["aas_core3/jsonization.py", "github:aas-core-works/aas-core3.0-micropython/aas_core3/jsonization.py"],
     ["aas_core3/stringification.py", "github:aas-core-works/aas-core3.0-micropython/aas_core3/stringification.py"],
     ["aas_core3/types.py", "github:aas-core-works/aas-core3.0-micropython/aas_core3/types.py"]
+    ["aas_core3/xmlization.py", "github:aas-core-works/aas-core3.0-micropython/aas_core3/xmlization.py"],
   ],
   "deps": [],
-  "version": "1.0.3"
+  "version": "1.0.5"
 }

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as fid:
 setup(
     name='aas-core3.0-micropython',
     # Synchronize with __init__.py and changelog.rst!
-    version="1.0.4",
+    version="1.0.5",
     description="Manipulate and de/serialize Asset Administration Shells in Micropython.",
     long_description=long_description,
     url="https://github.com/aas-core-works/aas-core3.0-micropython",


### PR DESCRIPTION
Notably, this propagates a fix in aas-core-meta, where a aas-core-meta fix for
references index constraint where indices in references were erroneously
assumed to be positive integers.
