### PR TITLE
Patch to aas-core3.0-python ff7d956

### DIFF
--- a/aas_core3/__init__.py
+++ b/aas_core3/__init__.py
@@ -1,7 +1,7 @@
 """Manipulate and de/serialize Asset Administration Shells in Micropython."""
 
 # Synchronize with __init__.py and changelog.rst!
-__version__ = "1.0.5"
+__version__ = "1.1.4"
 __author__ = "Marko Ristin"
 __copyright__ = "2024 Contributors to aas-core3.0-python"
 __license__ = "License :: OSI Approved :: MIT License"

--- a/aas_core3/xmlization.py
+++ b/aas_core3/xmlization.py
@@ -12,6 +12,101 @@ import aas_core3.types as aas_types
 NAMESPACE = "https://admin-shell.io/aas/3/0"
 
 
+def from_iterparse(iterator):
+
+    next_event_element = next(iterator, None)
+    if next_event_element is None:
+        raise DeserializationException(
+            "Expected the start element of an instance, but got the end-of-input"
+        )
+
+    next_event, next_element = next_event_element
+    if next_event != "start":
+        raise DeserializationException(
+            f"Expected the start element of an instance, but got event {next_event} and element {next_element.tag}"
+        )
+
+    try:
+        return _read_as_element(next_element, iterator)
+    except DeserializationException as exception:
+        exception.path._prepend(ElementSegment(next_element))
+        raise exception
+
+
+def from_stream(stream, has_iterparse=xml.etree.ElementTree):
+
+    iterator = has_iterparse.iterparse(stream, ["start", "end"])
+    return from_iterparse(_with_elements_cleared_after_yield(iterator))
+
+
+def from_file(path, has_iterparse=xml.etree.ElementTree):
+
+    with open(os.fspath(path), "rt", encoding="utf-8") as fid:
+        iterator = has_iterparse.iterparse(fid, ["start", "end"])
+        return from_iterparse(_with_elements_cleared_after_yield(iterator))
+
+
+def from_str(text, has_iterparse=xml.etree.ElementTree):
+
+    iterator = has_iterparse.iterparse(io.StringIO(text), ["start", "end"])
+    return from_iterparse(_with_elements_cleared_after_yield(iterator))
+
+
+def _read_as_element(element, iterator):
+
+    tag_wo_ns = _parse_element_tag(element)
+    read_as_sequence = _GENERAL_DISPATCH.get(tag_wo_ns, None)
+
+    if read_as_sequence is None:
+        raise DeserializationException(
+            f"Expected the element tag to be a valid model type of a concrete instance, but got tag {tag_wo_ns}"
+        )
+
+    return read_as_sequence(element, iterator)
+
+
+_GENERAL_DISPATCH = {
+    "extension": _read_extension_as_sequence,
+    "administrativeInformation": _read_administrative_information_as_sequence,
+    "qualifier": _read_qualifier_as_sequence,
+    "assetAdministrationShell": _read_asset_administration_shell_as_sequence,
+    "assetInformation": _read_asset_information_as_sequence,
+    "resource": _read_resource_as_sequence,
+    "specificAssetId": _read_specific_asset_id_as_sequence,
+    "submodel": _read_submodel_as_sequence,
+    "relationshipElement": _read_relationship_element_as_sequence,
+    "submodelElementList": _read_submodel_element_list_as_sequence,
+    "submodelElementCollection": _read_submodel_element_collection_as_sequence,
+    "property": _read_property_as_sequence,
+    "multiLanguageProperty": _read_multi_language_property_as_sequence,
+    "range": _read_range_as_sequence,
+    "referenceElement": _read_reference_element_as_sequence,
+    "blob": _read_blob_as_sequence,
+    "file": _read_file_as_sequence,
+    "annotatedRelationshipElement": _read_annotated_relationship_element_as_sequence,
+    "entity": _read_entity_as_sequence,
+    "eventPayload": _read_event_payload_as_sequence,
+    "basicEventElement": _read_basic_event_element_as_sequence,
+    "operation": _read_operation_as_sequence,
+    "operationVariable": _read_operation_variable_as_sequence,
+    "capability": _read_capability_as_sequence,
+    "conceptDescription": _read_concept_description_as_sequence,
+    "reference": _read_reference_as_sequence,
+    "key": _read_key_as_sequence,
+    "langStringNameType": _read_lang_string_name_type_as_sequence,
+    "langStringTextType": _read_lang_string_text_type_as_sequence,
+    "environment": _read_environment_as_sequence,
+    "embeddedDataSpecification": _read_embedded_data_specification_as_sequence,
+    "levelType": _read_level_type_as_sequence,
+    "valueReferencePair": _read_value_reference_pair_as_sequence,
+    "valueList": _read_value_list_as_sequence,
+    "langStringPreferredNameTypeIec61360": _read_lang_string_preferred_name_type_iec_61360_as_sequence,
+    "langStringShortNameTypeIec61360": _read_lang_string_short_name_type_iec_61360_as_sequence,
+    "langStringDefinitionTypeIec61360": _read_lang_string_definition_type_iec_61360_as_sequence,
+    "dataSpecificationIec61360": _read_data_specification_iec_61360_as_sequence,
+}
+
+
 class _Serializer(aas_types.AbstractVisitor):
 
     def _write_first_start_element_with_namespace(self, name):

--- a/aas_core3/xmlization.pyi
+++ b/aas_core3/xmlization.pyi
@@ -34,6 +34,166 @@ else:
 
 NAMESPACE = "https://admin-shell.io/aas/3/0"
 
+def from_iterparse(iterator: Iterator[Tuple[str, Element]]) -> aas_types.Class:
+    """
+    Read an instance from the :paramref:`iterator`.
+
+    The type of the instance is determined by the very first start element.
+
+    Example usage:
+
+    .. code-block::
+
+        import pathlib
+        import xml.etree.ElementTree as ET
+
+        import aas_core3.xmlization as aas_xmlization
+
+        path = pathlib.Path(...)
+        with path.open("rt") as fid:
+            iterator = ET.iterparse(
+                source=fid,
+                events=['start', 'end']
+            )
+            instance = aas_xmlization.from_iterparse(
+                iterator
+            )
+
+        # Do something with the ``instance``
+
+    :param iterator:
+        Input stream of ``(event, element)`` coming from
+        :py:func:`xml.etree.ElementTree.iterparse` with the argument
+        ``events=["start", "end"]``
+    :raise: :py:class:`DeserializationException` if unexpected input
+    :return:
+        Instance of :py:class:`.types.Class` read from the :paramref:`iterator`
+    """
+    ...
+
+def from_stream(
+    stream: TextIO, has_iterparse: HasIterparse = xml.etree.ElementTree
+) -> aas_types.Class:
+    """
+    Read an instance from the :paramref:`stream`.
+
+    The type of the instance is determined by the very first start element.
+
+    Example usage:
+
+    .. code-block::
+
+        import aas_core3.xmlization as aas_xmlization
+
+        with open_some_stream_over_network(...) as stream:
+            instance = aas_xmlization.from_stream(
+                stream
+            )
+
+        # Do something with the ``instance``
+
+    :param stream:
+        representing an instance in XML
+    :param has_iterparse:
+        Module containing ``iterparse`` function.
+
+        Default is to use :py:mod:`xml.etree.ElementTree` from the standard
+        library. If you have to deal with malicious input, consider using
+        a library such as `defusedxml.ElementTree`_.
+    :raise: :py:class:`DeserializationException` if unexpected input
+    :return:
+        Instance read from :paramref:`stream`
+    """
+    ...
+
+def from_file(
+    path: PathLike, has_iterparse: HasIterparse = xml.etree.ElementTree
+) -> aas_types.Class:
+    """
+    Read an instance from the file at the :paramref:`path`.
+
+    Example usage:
+
+    .. code-block::
+
+        import pathlib
+        import aas_core3.xmlization as aas_xmlization
+
+        path = pathlib.Path(...)
+        instance = aas_xmlization.from_file(
+            path
+        )
+
+        # Do something with the ``instance``
+
+    :param path:
+        to the file representing an instance in XML
+    :param has_iterparse:
+        Module containing ``iterparse`` function.
+
+        Default is to use :py:mod:`xml.etree.ElementTree` from the standard
+        library. If you have to deal with malicious input, consider using
+        a library such as `defusedxml.ElementTree`_.
+    :raise: :py:class:`DeserializationException` if unexpected input
+    :return:
+        Instance read from the file at :paramref:`path`
+    """
+    ...
+
+def from_str(
+    text: str, has_iterparse: HasIterparse = xml.etree.ElementTree
+) -> aas_types.Class:
+    """
+    Read an instance from the :paramref:`text`.
+
+    Example usage:
+
+    .. code-block::
+
+        import pathlib
+        import aas_core3.xmlization as aas_xmlization
+
+        text = "<...>...</...>"
+        instance = aas_xmlization.from_str(
+            text
+        )
+
+        # Do something with the ``instance``
+
+    :param text:
+        representing an instance in XML
+    :param has_iterparse:
+        Module containing ``iterparse`` function.
+
+        Default is to use :py:mod:`xml.etree.ElementTree` from the standard
+        library. If you have to deal with malicious input, consider using
+        a library such as `defusedxml.ElementTree`_.
+    :raise: :py:class:`DeserializationException` if unexpected input
+    :return:
+        Instance read from :paramref:`text`
+    """
+    ...
+
+def _read_as_element(
+    element: Element, iterator: Iterator[Tuple[str, Element]]
+) -> aas_types.Class:
+    """
+    Read an instance from :paramref:`iterator`, including the end element.
+
+    :param element: start element
+    :param iterator:
+        Input stream of ``(event, element)`` coming from
+        :py:func:`xml.etree.ElementTree.iterparse` with the argument
+        ``events=["start", "end"]``
+    :raise: :py:class:`DeserializationException` if unexpected input
+    :return: parsed instance
+    """
+    ...
+
+_GENERAL_DISPATCH: Mapping[
+    str, Callable[[Element, Iterator[Tuple[str, Element]]], aas_types.Class]
+]
+
 class _Serializer(aas_types.AbstractVisitor):
     """Encode instances as XML and write them to :py:attr:`~stream`."""
 

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ See:
 https://packaging.python.org/en/latest/distributing.html
 https://github.com/pypa/sampleproject
 """
+
 import os
 import sys
 
@@ -19,7 +20,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as fid:
 setup(
     name='aas-core3.0-micropython',
     # Synchronize with __init__.py and changelog.rst!
-    version="1.0.5",
+    version="1.1.4",
     description="Manipulate and de/serialize Asset Administration Shells in Micropython.",
     long_description=long_description,
     url="https://github.com/aas-core-works/aas-core3.0-micropython",


### PR DESCRIPTION
There were some fixes in Python SDK, so we propagate them to this repository with patching.

The version of the original Python code is [aas-core3.0-python ff7d956].

[aas-core3.0-python ff7d956]: https://github.com/aas-core-works/aas-core3.0-python/commit/ff7d956fadae2901dbde0427507c4739a6d5804a